### PR TITLE
docs(openai): note OpenAI-compatible multi-model gateway base_url

### DIFF
--- a/notebooks/integrations/openai/README.md
+++ b/notebooks/integrations/openai/README.md
@@ -2,6 +2,8 @@
 
 This folder contains notebooks that demonstrate how to integrate popular OpenAI services with Elasticsearch.
 
+> **Tip:** The OpenAI Python client also works with OpenAI-compatible multi-model gateways via `base_url` when you are not calling OpenAI directly — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 The following notebooks are available:
 
 - [OpenAI embeddings and retrieval augmented generation (RAG)](#openai-embeddings-and-retrieval-augmented-generation-rag)


### PR DESCRIPTION
## Summary

The OpenAI integration notebooks use the OpenAI Python client against OpenAI endpoints. This PR adds a short tip that the same client also works with OpenAI-compatible multi-model gateways via `base_url` — DaoXE (`https://api.daoxe.com/v1`) is one concrete example.

Docs only — no notebook code changes.

## Test plan
- [ ] Notebook list/content unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>