### PR TITLE
Define missing kbn_request helper in context-management notebook

### DIFF
--- a/supporting-blog-content/precomputed-context-technical-walkthrough-part-1/index-metadata-kis.ipynb
+++ b/supporting-blog-content/precomputed-context-technical-walkthrough-part-1/index-metadata-kis.ipynb
@@ -77,7 +77,22 @@
     "ELASTIC_API_KEY = getpass(\"Elastic API key: \")\n",
     "\n",
     "client = Elasticsearch(hosts=[ES_URL], api_key=ELASTIC_API_KEY)\n",
-    "print(client.info())"
+    "print(client.info())\n",
+    "\n",
+    "\n",
+    "def kbn_request(method, path, body=None, api_version=None):\n",
+    "    \"\"\"Call the Kibana REST API. api_version sets Elastic-Api-Version for\n",
+    "    versioned APIs like Workflows.\"\"\"\n",
+    "    headers = {\n",
+    "        \"Authorization\": f\"ApiKey {ELASTIC_API_KEY}\",\n",
+    "        \"kbn-xsrf\": \"true\",\n",
+    "        \"Content-Type\": \"application/json\",\n",
+    "    }\n",
+    "    if api_version:\n",
+    "        headers[\"Elastic-Api-Version\"] = api_version\n",
+    "    resp = requests.request(method, f\"{KIBANA_URL}{path}\", headers=headers, json=body)\n",
+    "    resp.raise_for_status()\n",
+    "    return resp.json() if resp.content else None"
    ]
   },
   {


### PR DESCRIPTION
Follow-up to #573.

## Problem

As noted in [this review comment](https://github.com/elastic/elasticsearch-labs/pull/573#issuecomment-5183776359), `kbn_request` is called in the workflow create/run/wait and cleanup cells of `index-metadata-kis.ipynb` but was never defined — it's not part of the Elasticsearch Python library.

## Fix

Add a `kbn_request` helper to the client-init cell (where `KIBANA_URL`, `ELASTIC_API_KEY`, and `requests` are already in scope). It:
- Authenticates with the same API key as the Elasticsearch client
- Sends the `kbn-xsrf` header Kibana requires
- Maps `api_version` to the `Elastic-Api-Version` header needed by the versioned Workflows API
- Returns parsed JSON, matching all four call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)